### PR TITLE
Allow multiple path parameters on the configure step

### DIFF
--- a/modules/configure.py
+++ b/modules/configure.py
@@ -399,8 +399,10 @@ def configure(args) :
     args = add_args(args)
 
     for key, value in args.__dict__.items() :
-        if value is not None :
-            configs[configs.T[0] == key, 1] = value
+        # Allow multiple --path
+        if key != 'path':
+            if value is not None :
+                configs[configs.T[0] == key, 1] = value
     externals = prepare_externals(conf=configs)
     if args.install :
         install_externals()


### PR DESCRIPTION
Related to https://github.com/zheminzhou/EToKi/issues/12

```
EToKi.py configure     --path spades=$(which spades.py)     --path trf=$(which trf)
usage: EToKi [-h] {configure,prepare,assemble,MLSTdb,MLSType,MLSTsum,cgMLST,align,phylo,EBEis,uberBlast,clust,isCRISPOL} ...

options:
  -h, --help            show this help message and exit

sub-commands:
  {configure,prepare,assemble,MLSTdb,MLSType,MLSTsum,cgMLST,align,phylo,EBEis,uberBlast,clust,isCRISPOL}
    configure           install and/or configure 3rd party programs
    prepare             trim, collapse, downsize and rename the short reads.
    assemble            de novo or reference-guided assembly for genomic or metagenomic reads
    MLSTdb              Set up exemplar alleles and database for MLST schemes
    MLSType             MLST nomenclature using a local set of references
    MLSTsum             Summarise MLSType results and assign new allele designations
    cgMLST              Select a list of genes for the cgMLST scheme
    align               align multiple queried genomes to a single reference
    phylo               infer phylogeny and ancestral states from genomic alignments
    EBEis               in silico serotype prediction for Escherichia coli and Shigella spp.
    uberBlast           Use Blastn, uBlastp, minimap2 and/or mmseqs to identify similar sequences
    clust               linear-time clustering of short sequences using mmseqs linclust
    isCRISPOL           in silico prediction of CRISPOL array for Salmonella enterica serovar Typhimurium
```

With change:
```
EToKi.py configure     --path spades=$(which spades.py)     --path trf=$(which trf)
2022-09-21 20:35:13.889938      bbduk ("/home/robert_petit/miniconda3/envs/test-etoki/bin/bbduk.sh") is present.
2022-09-21 20:35:13.898419      bbmerge ("/home/robert_petit/miniconda3/envs/test-etoki/bin/bbmerge.sh") is present.
2022-09-21 20:35:13.944494      blastn ("/home/robert_petit/miniconda3/envs/test-etoki/bin/blastn") is present.
2022-09-21 20:35:13.988925      blastp ("/home/robert_petit/miniconda3/envs/test-etoki/bin/blastp") is present.
2022-09-21 20:35:14.030169      bowtie2 ("/home/robert_petit/miniconda3/envs/test-etoki/bin/bowtie2") is present.
2022-09-21 20:35:14.076982      bowtie2build ("/home/robert_petit/miniconda3/envs/test-etoki/bin/bowtie2-build") is present.
2022-09-21 20:35:14.078243      bwa ("/home/robert_petit/miniconda3/envs/test-etoki/bin/bwa") is present.
2022-09-21 20:35:14.081551      diamond ("/home/robert_petit/miniconda3/envs/test-etoki/bin/diamond") is present.
2022-09-21 20:35:14.082775      fasttree ("/home/robert_petit/miniconda3/envs/test-etoki/bin/FastTreeMP") is present.
2022-09-21 20:35:14.082838      ERROR - flye ("/home/robert_petit/miniconda3/envs/test-etoki/share/etoki-1.2.2/externals/flye") is not present.
2022-09-21 20:35:14.082875      ERROR - kraken2 ("/home/robert_petit/miniconda3/envs/test-etoki/share/etoki-1.2.2/externals/kraken2") is not present.
2022-09-21 20:35:14.082910      ERROR - lastal ("/home/robert_petit/miniconda3/envs/test-etoki/share/etoki-1.2.2/externals/lastal") is not present.
2022-09-21 20:35:14.082977      ERROR - lastdb ("/home/robert_petit/miniconda3/envs/test-etoki/share/etoki-1.2.2/externals/lastdb") is not present.
2022-09-21 20:35:14.083020      ERROR - makeblastdb ("/home/robert_petit/miniconda3/envs/test-etoki/share/etoki-1.2.2/externals/makeblastdb") is not present.
2022-09-21 20:35:14.083055      ERROR - megahit ("/home/robert_petit/miniconda3/envs/test-etoki/share/etoki-1.2.2/externals/MEGAHIT-1.2.9-Linux-x86_64-static/bin/megahit") is not present.
2022-09-21 20:35:14.083088      ERROR - minimap2 ("/home/robert_petit/miniconda3/envs/test-etoki/share/etoki-1.2.2/externals/minimap2") is not present.
2022-09-21 20:35:14.083121      ERROR - mmseqs ("/home/robert_petit/miniconda3/envs/test-etoki/share/etoki-1.2.2/externals/mmseqs") is not present.
2022-09-21 20:35:14.083153      ERROR - nextpolish ("/home/robert_petit/miniconda3/envs/test-etoki/share/etoki-1.2.2/externals/nextpolish") is not present.
2022-09-21 20:35:14.083185      ERROR - pilercr ("/home/robert_petit/miniconda3/envs/test-etoki/share/etoki-1.2.2/externals/pilercr") is not present.
2022-09-21 20:35:14.083218      ERROR - pilon ("/home/robert_petit/miniconda3/envs/test-etoki/share/etoki-1.2.2/externals/pilon-1.23.jar") is not present.
2022-09-21 20:35:14.083250      ERROR - rapidnj ("/home/robert_petit/miniconda3/envs/test-etoki/share/etoki-1.2.2/externals/rapidnj") is not present.
2022-09-21 20:35:14.083282      ERROR - raxml ("/home/robert_petit/miniconda3/envs/test-etoki/share/etoki-1.2.2/externals/raxmlHPC") is not present.
2022-09-21 20:35:14.083313      ERROR - raxml_ng ("/home/robert_petit/miniconda3/envs/test-etoki/share/etoki-1.2.2/externals/raxml-ng") is not present.
2022-09-21 20:35:14.083346      ERROR - repair ("/home/robert_petit/miniconda3/envs/test-etoki/share/etoki-1.2.2/externals/repair.sh") is not present.
2022-09-21 20:35:14.083377      ERROR - samtools ("/home/robert_petit/miniconda3/envs/test-etoki/share/etoki-1.2.2/externals/samtools") is not present.
2022-09-21 20:35:14.312982      spades ("/home/robert_petit/miniconda3/envs/test-etoki/bin/spades.py") is present.
2022-09-21 20:35:14.314230      trf ("/home/robert_petit/miniconda3/envs/test-etoki/bin/trf") is present.
2022-09-21 20:35:14.314336      ERROR - usearch ("/home/robert_petit/miniconda3/envs/test-etoki/share/etoki-1.2.2/externals/usearch") is not present.
2022-09-21 20:35:14.314360      WARNING - kraken_database is not present.
You can still use EToKi except the parameter "--kraken" in EToKi assemble will not work.
Alternatively you can download minikraken2 database using --download_krakenDB or pass an pre-installed database into EToKi using --link_krakenDB.
```